### PR TITLE
Added WSM DC and common settings

### DIFF
--- a/drawing-board/cooking-loose/outputs.tf
+++ b/drawing-board/cooking-loose/outputs.tf
@@ -7,3 +7,14 @@ output "public_ip_dns_name" {
   description = "fqdn to connect to the first vm provisioned."
   value       = "${azurerm_public_ip.cl_jump_pip.fqdn}"
 }
+
+output "rdp_command" {
+  value = <<RDPCOMMAND
+  ### Use command below to connect via RDP ###
+  [
+    Command:  mstsc /v:${azurerm_public_ip.cl_jump_pip.fqdn} /admin
+    Username: ${var.vm["admin_username"]}
+    Password: ${var.vm["admin_password"]}
+  ]
+RDPCOMMAND
+}

--- a/drawing-board/cooking-loose/terraform.tfvars
+++ b/drawing-board/cooking-loose/terraform.tfvars
@@ -2,13 +2,29 @@ resource_group_name = "cl-dev-rg"
 
 location = "EastUS"
 
-admin_username = "cladmin"
-
-admin_password = "G0ld5t4r!"
-
 vnet_name = "cl-dev-vnet"
 
 vnet_address_space = ["192.168.0.0/16"]
+
+# Global VM vars
+vm = {
+  # User
+  admin_username = "cladmin"
+  admin_password = "G0ld5t4r!"
+
+  # Storage
+  vm_size           = "Standard_DS1_v2"
+  sku               = "2016-Datacenter-smalldisk"
+  managed_disk_type = "StandardSSD_LRS"
+
+  # os_profile_windows_config
+  provision_vm_agent        = false
+  enable_automatic_upgrades = false
+  timezone                  = "GMT Standard Time"
+  # winrm                     = "HTTP"
+
+  # additional_unattend_config = ""
+}
 
 remote = {
   "subnet_name"   = "cl-dev-remote-subnet"

--- a/drawing-board/cooking-loose/variables.tf
+++ b/drawing-board/cooking-loose/variables.tf
@@ -1,11 +1,13 @@
 variable "resource_group_name" {}
 variable "location" {}
-variable "admin_username" {}
-variable "admin_password" {}
 variable "vnet_name" {}
 
 variable "vnet_address_space" {
   type = "list"
+}
+
+variable "vm" {
+  type = "map"
 }
 
 variable "remote" {


### PR DESCRIPTION
I've added the WSM DC, which you can RDP to from the Jump server. It seems the default rules allow this out of the box, even between subnets in a different NSG.

There are also now common settings we can use in the "vm" map variable.  I felt this was cleaner than individual vars per setting.

Any issues, let me know.